### PR TITLE
Restore cookie sandbox functionality

### DIFF
--- a/src/webSession.js
+++ b/src/webSession.js
@@ -29,6 +29,7 @@ const Translate = require('./translation/translate');
 const HTTP = require('./http');
 const Translators = require('./translators');
 const SearchEndpoint = require('./searchEndpoint');
+const { jar: cookieJar } = require('request');
 
 const SERVER_TRANSLATION_TIMEOUT = 30;
 
@@ -98,9 +99,7 @@ SearchSession.prototype.handleURL = async function () {
 		}*/
 		
 		// New request
-		/*this._cookieSandbox = new Zotero.CookieSandbox(null, url);
-		this._cookieSandbox.setTimeout(SERVER_TRANSLATION_TIMEOUT*1000,
-			this.timeout.bind(this));*/
+		this._cookieSandbox = cookieJar();
 		
 		let resolve;
 		let reject;
@@ -140,7 +139,7 @@ SearchSession.prototype.handleURL = async function () {
 			}
 			resolve();
 		});
-		//translate.setCookieSandbox(this._cookieSandbox);
+		translate.setCookieSandbox(this._cookieSandbox);
 		
 		try {
 			await HTTP.processDocuments(
@@ -150,8 +149,8 @@ SearchSession.prototype.handleURL = async function () {
 					// This could be optimized by only running detect on secondary translators
 					// if the first fails, but for now just run detect on all
 					return translate.getTranslators(true);
-				}/*,
-				this._cookieSandbox*/
+				},
+				this._cookieSandbox
 			);
 			return promise;
 		}


### PR DESCRIPTION
Attempt at addressing https://github.com/zotero/translation-server-v2/issues/26

Per report, 

```
curl -d 'http://www.bioone.org/doi/abs/10.1642/0004-8038%282005%29122%5B0673%3APROAGP%5D2.0.CO%3B2' -H 'Content-Type: text/plain' http://127.0.0.1:1969/web
```

now works, although only some of the time. Sometimes the RIS response from the journal is empty and the server returns an empty array.