### PR TITLE
Use quotes rather than backticks in Debug.log

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -50,5 +50,5 @@ Translators.init()
 	
 	var port = config.get('port');
 	app.listen(port);
-	Debug.log(`Listening on 0.0.0.0:${port}`);
+	Debug.log('Listening on 0.0.0.0:${port}');
 });


### PR DESCRIPTION
Backticks were throwing up a "Weird error 8"; presumably quotes were intended?