### PR TITLE
Translate doi.org URL instead of extracting DOI

### DIFF
--- a/src/webSession.js
+++ b/src/webSession.js
@@ -75,13 +75,6 @@ WebSession.prototype.handleURL = async function () {
 		}
 	}
 	
-	// If a doi.org URL, use search handler
-	if (url.match(/^https?:\/\/[^\/]*doi\.org\//)) {
-		let doi = Zotero.Utilities.cleanDOI(url);
-		await SearchEndpoint.handleIdentifier(this.ctx, { DOI: doi });
-		return;
-	}
-	
 	var urlsToTry = config.get('deproxifyURLs') ? this.deproxifyURL(url) : [url];
 	for (let i = 0; i < urlsToTry.length; i++) {
 		let url = urlsToTry[i];


### PR DESCRIPTION
Fixes #48. The problem occurs only for doi.org URLs. The fix removes DOI from doi.org URL parsing code and solves the incorrectly parsed DOI problem. DOI is still parsed on [URL translation failure](https://github.com/zotero/translation-server/blob/master/src/webSession.js#L172).