### PR TITLE
Make the listening host configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -4,6 +4,7 @@
 	"deproxifyURLs": false, // Automatically try deproxified versions of URLs
 	"identifierSearchLambda": "", // Identifier search Lambda function for text search
 	"port": 1969,
+	"host": "0.0.0.0", // host to listen on
 	"textSearchTimeout": 5,
 	"translators": {
 		"CrossrefREST.email": "" // Pass an email to Crossref REST API to utilize the faster servers pool

--- a/src/server.js
+++ b/src/server.js
@@ -53,7 +53,7 @@ Translators.init()
 	if (process.env.NODE_ENV == 'test') return;
 	
 	var port = config.get('port');
-	var host = config.has('host') ? config.get('host') : '0.0.0.0';
+	var host = config.get('host');
 	app.listen(port, host);
 	Debug.log(`Listening on ${host}:${port}`);
 });

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,7 @@ Translators.init()
 	if (process.env.NODE_ENV == 'test') return;
 	
 	var port = config.get('port');
-	app.listen(port);
-	Debug.log(`Listening on 0.0.0.0:${port}`);
+	var host = config.has('host') ? config.get('host') : '0.0.0.0';
+	app.listen(port, host);
+	Debug.log(`Listening on ${host}:${port}`);
 });


### PR DESCRIPTION
By default translation-server listens on `0.0.0.0`. I find it useful to be able not to expose translation-server to the outside world, so to listen on `127.0.0.1` instead. This makes the listening host configurable, without changing the default value (and still accepting existing configurations if they did not include that field).