### PR TITLE
Automatic translator updates

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -15,5 +15,5 @@
 	"translatorsDirectory": "./modules/translators",
 	"translatorsAutoUpdate" : true,
 	"REPOSITORY_URL" : "https://repo.zotero.org/repo",
-	"metadataValidForHours" : 1
+	"metadataValidForHours" : 24
 }

--- a/config/default.json5
+++ b/config/default.json5
@@ -12,5 +12,8 @@
 	},
 	"trustProxyHeaders": false, // Trust X-Forwarded-For when logging requests
 	"userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
-	"translatorsDirectory": "./modules/translators"
+	"translatorsDirectory": "./modules/translators",
+	"translatorsAutoUpdate" : true,
+	"REPOSITORY_URL" : "https://repo.zotero.org/repo",
+	"metadataValidForHours" : 1
 }

--- a/src/exportEndpoint.js
+++ b/src/exportEndpoint.js
@@ -49,7 +49,7 @@ var ExportEndpoint = module.exports = {
 			ctx.throw(400, "Input must be an array of items as JSON");
 		}
 		
-		var translator = Zotero.Translators.get(translatorID);
+		var translator = await Zotero.Translators.updateTranslatorIfNeeded([translatorID]);
 		var legacy = Zotero.Utilities.semverCompare('4.0.27', translator.metadata.minVersion) > 0;
 		
 		// Emulate itemsToExportFormat as best as we can

--- a/src/importEndpoint.js
+++ b/src/importEndpoint.js
@@ -37,7 +37,8 @@ module.exports = {
 			ctx.throw(500, 'No suitable translators found', { expose: true });
 			return;
 		}
-		translate.setTranslator(translators[0]);
+		const updatedTranslator = await Translators.updateTranslatorIfNeeded(translators[0].translatorID);
+		translate.setTranslator(updatedTranslator);
 		var items = await translate.translate({ libraryID: 1 });
 		
 		ctx.set('Content-Type', 'application/json');

--- a/src/importEndpoint.js
+++ b/src/importEndpoint.js
@@ -37,7 +37,7 @@ module.exports = {
 			ctx.throw(500, 'No suitable translators found', { expose: true });
 			return;
 		}
-		const updatedTranslator = await Translators.updateTranslatorIfNeeded(translators[0].translatorID);
+		const updatedTranslator = await Zotero.Translators.updateTranslatorIfNeeded(translators[0].translatorID);
 		translate.setTranslator(updatedTranslator);
 		var items = await translate.translate({ libraryID: 1 });
 		

--- a/src/searchEndpoint.js
+++ b/src/searchEndpoint.js
@@ -26,7 +26,6 @@
 const config = require('config');
 const Translate = require('./translation/translate');
 const TextSearch = require('./textSearch');
-const Translators = require('./translators');
 
 var SearchEndpoint = module.exports = {
 	handle: async function (ctx, next) {
@@ -66,7 +65,7 @@ var SearchEndpoint = module.exports = {
 			if (!translators.length) {
 				ctx.throw(501, "No translators available", { expose: true });
 			}
-			translators = await Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
+			translators = await Zotero.Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
 			translate.setTranslator(translators);
 
 			var items = await translate.translate({

--- a/src/searchEndpoint.js
+++ b/src/searchEndpoint.js
@@ -26,6 +26,7 @@
 const config = require('config');
 const Translate = require('./translation/translate');
 const TextSearch = require('./textSearch');
+const Translators = require('./translators');
 
 var SearchEndpoint = module.exports = {
 	handle: async function (ctx, next) {
@@ -61,12 +62,13 @@ var SearchEndpoint = module.exports = {
 		try {
 			var translate = new Translate.Search();
 			translate.setIdentifier(identifier);
-			let translators = await translate.getTranslators();
+			var translators = await translate.getTranslators();
 			if (!translators.length) {
 				ctx.throw(501, "No translators available", { expose: true });
 			}
+			translators = await Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
 			translate.setTranslator(translators);
-			
+
 			var items = await translate.translate({
 				libraryID: false
 			});

--- a/src/textSearch.js
+++ b/src/textSearch.js
@@ -171,7 +171,8 @@ async function search(query, start) {
 				}
 				continue;
 			}
-			translate.setTranslator(translators);
+			updatedTranslators = await Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
+			translate.setTranslator(updatedTranslators);
 			
 			let newItems = await translate.translate({
 				libraryID: false
@@ -295,7 +296,8 @@ async function queryCrossref(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Crossref REST
-		translate.setTranslator("0a61e167-de9a-4f93-a68a-628b48855909");
+		updatedTranslator = await Translators.updateTranslatorIfNeeded(["0a61e167-de9a-4f93-a68a-628b48855909"]);
+		translate.setTranslator(updatedTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
 	}
@@ -313,7 +315,8 @@ async function queryLibraries(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Library of Congress ISBN
-		translate.setTranslator("c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9");
+		updatedTranslator = await Translators.updateTranslatorIfNeeded(["c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9"]);
+		translate.setTranslator(updatedTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
 	}
@@ -322,7 +325,8 @@ async function queryLibraries(query) {
 		try {
 			let translate = new Zotero.Translate.Search();
 			// Gemeinsamer Bibliotheksverbund ISBN
-			translate.setTranslator("de0eef58-cb39-4410-ada0-6b39f43383f9");
+			updatedTranslator = await Translators.updateTranslatorIfNeeded(["de0eef58-cb39-4410-ada0-6b39f43383f9"]);
+			translate.setTranslator(updatedTranslator);
 			translate.setSearch({query});
 			items = await translate.translate({libraryID: false});
 		}

--- a/src/textSearch.js
+++ b/src/textSearch.js
@@ -171,7 +171,7 @@ async function search(query, start) {
 				}
 				continue;
 			}
-			updatedTranslators = await Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
+			updatedTranslators = await Zotero.Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
 			translate.setTranslator(updatedTranslators);
 			
 			let newItems = await translate.translate({
@@ -296,7 +296,7 @@ async function queryCrossref(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Crossref REST
-		updatedTranslator = await Translators.updateTranslatorIfNeeded(["0a61e167-de9a-4f93-a68a-628b48855909"]);
+		updatedTranslator = await Zotero.Translators.updateTranslatorIfNeeded("0a61e167-de9a-4f93-a68a-628b48855909");
 		translate.setTranslator(updatedTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
@@ -315,7 +315,7 @@ async function queryLibraries(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Library of Congress ISBN
-		updatedTranslator = await Translators.updateTranslatorIfNeeded(["c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9"]);
+		updatedTranslator = await Zotero.Translators.updateTranslatorIfNeeded("c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9");
 		translate.setTranslator(updatedTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
@@ -325,7 +325,7 @@ async function queryLibraries(query) {
 		try {
 			let translate = new Zotero.Translate.Search();
 			// Gemeinsamer Bibliotheksverbund ISBN
-			updatedTranslator = await Translators.updateTranslatorIfNeeded(["de0eef58-cb39-4410-ada0-6b39f43383f9"]);
+			updatedTranslator = await Zotero.Translators.updateTranslatorIfNeeded("de0eef58-cb39-4410-ada0-6b39f43383f9");
 			translate.setTranslator(updatedTranslator);
 			translate.setSearch({query});
 			items = await translate.translate({libraryID: false});

--- a/src/translators.js
+++ b/src/translators.js
@@ -210,7 +210,7 @@ Translators = Object.assign(Translators, new function () {
 	};
 
 	/**
-	 * @param {[String]} translatorIDS  - array of translatorIDS
+	 * @param {[String]|String} translatorIDS  - array of translatorIDS or a single transactionID
 	 * Go through translators, check if lastUpdated time from the metadata is after
 	 * lastUpdated recorded inside of the translator. 
 	 * If yes, we fetch the code from
@@ -219,6 +219,10 @@ Translators = Object.assign(Translators, new function () {
 	 */
 	this.updateTranslatorIfNeeded = async function (translatorIDS) {
 		const translators = [];
+
+		if (!Array.isArray(translatorIDS)){
+			translatorIDS = [translatorIDS];
+		}
 		// Check if it is time to re-fresh metadata
 		if (_metadata?.updateAt < new Date()) {
 			await this.fetchMetadata();
@@ -232,12 +236,12 @@ Translators = Object.assign(Translators, new function () {
 					updateCandidate.lastUpdated = Zotero.Date.dateToSQL(new Date());
 					updateCandidate.code = codeRequest.responseText;
 				} catch (e) {
-					Zotero.debug("Could not fetch translator's code for " + translator.translatorID);
+					Zotero.debug("Could not fetch translator's code for " + translatorID);
 				}
 			}
 			translators.push(updateCandidate);
 		}
-		return translators;
+		return translators.length == 1 ? translators[0] : translators;
 	}
 
 	/**

--- a/src/webSession.js
+++ b/src/webSession.js
@@ -240,7 +240,7 @@ WebSession.prototype.translate = async function (translate, translators) {
 	var updatedTranslator;
 	var items;
 	while (translator = translators.shift()) {
-		updatedTranslator = await Translators.updateTranslatorIfNeeded([translator.translatorID]);
+		updatedTranslator = await Zotero.Translators.updateTranslatorIfNeeded(translator.translatorID);
 		translate.setTranslator(updatedTranslator);
 		try {
 			items = await translate.translate({

--- a/src/webSession.js
+++ b/src/webSession.js
@@ -237,9 +237,11 @@ WebSession.prototype.translate = async function (translate, translators) {
 	}
 	
 	var translator;
+	var updatedTranslator;
 	var items;
 	while (translator = translators.shift()) {
-		translate.setTranslator(translator);
+		updatedTranslator = await Translators.updateTranslatorIfNeeded([translator.translatorID]);
+		translate.setTranslator(updatedTranslator);
 		try {
 			items = await translate.translate({
 				libraryID: false


### PR DESCRIPTION
Addresses [Issue # 1](https://github.com/zotero/translation-server/issues/1)
Automatic translator updates for /web requests. The logic is:
1. On load, fetch the metadata. Once it is loaded, check if there are new translators in the metadata that are not present in _cache. Load them up as well if so.
2. Once the request comes in and all relevant translators are fetched, use `updateTranslatorIfNeeded` function to check if their lastUpdated date is before the lastUpdated date in the metadata. If so, load the translator's code from the repo, update the _cache.
3. Returns updated (if applicable) translators to translate the items. 