### PR TITLE
Auto updating translators based on metadata

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -12,5 +12,8 @@
 	},
 	"trustProxyHeaders": false, // Trust X-Forwarded-For when logging requests
 	"userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
-	"translatorsDirectory": "./modules/translators"
+	"translatorsDirectory": "./modules/translators",
+	"translatorsAutoUpdate" : true,
+	"REPOSITORY_URL" : "https://repo.zotero.org/repo",
+	"metadataValidForHours" : 24
 }

--- a/src/exportEndpoint.js
+++ b/src/exportEndpoint.js
@@ -49,7 +49,7 @@ var ExportEndpoint = module.exports = {
 			ctx.throw(400, "Input must be an array of items as JSON");
 		}
 		
-		var translator = Zotero.Translators.get(translatorID);
+		var translator = await Zotero.Translators.updateTranslatorIfNeeded([translatorID]);
 		var legacy = Zotero.Utilities.semverCompare('4.0.27', translator.metadata.minVersion) > 0;
 		
 		// Emulate itemsToExportFormat as best as we can
@@ -69,7 +69,7 @@ var ExportEndpoint = module.exports = {
 		}
 		
 		var translate = new Translate.Export();
-		translate.setTranslator(translatorID);
+		translate.setTranslator(translator);
 		translate.setItems(items);
 		try {
 			await new Promise(function (resolve, reject) {

--- a/src/importEndpoint.js
+++ b/src/importEndpoint.js
@@ -37,7 +37,8 @@ module.exports = {
 			ctx.throw(500, 'No suitable translators found', { expose: true });
 			return;
 		}
-		translate.setTranslator(translators[0]);
+		const upToDateTranslator = await Zotero.Translators.updateTranslatorIfNeeded(translators[0].translatorID);
+		translate.setTranslator(upToDateTranslator);
 		var items = await translate.translate({ libraryID: 1 });
 		
 		ctx.set('Content-Type', 'application/json');

--- a/src/searchEndpoint.js
+++ b/src/searchEndpoint.js
@@ -61,12 +61,13 @@ var SearchEndpoint = module.exports = {
 		try {
 			var translate = new Translate.Search();
 			translate.setIdentifier(identifier);
-			let translators = await translate.getTranslators();
+			var translators = await translate.getTranslators();
 			if (!translators.length) {
 				ctx.throw(501, "No translators available", { expose: true });
 			}
+			translators = await Zotero.Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
 			translate.setTranslator(translators);
-			
+
 			var items = await translate.translate({
 				libraryID: false
 			});

--- a/src/textSearch.js
+++ b/src/textSearch.js
@@ -171,7 +171,8 @@ async function search(query, start) {
 				}
 				continue;
 			}
-			translate.setTranslator(translators);
+			upToDateTranslators = await Zotero.Translators.updateTranslatorIfNeeded(translators.map(tr => tr.translatorID));
+			translate.setTranslator(upToDateTranslators);
 			
 			let newItems = await translate.translate({
 				libraryID: false
@@ -295,7 +296,8 @@ async function queryCrossref(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Crossref REST
-		translate.setTranslator("0a61e167-de9a-4f93-a68a-628b48855909");
+		upToDateTranslator = await Zotero.Translators.updateTranslatorIfNeeded("0a61e167-de9a-4f93-a68a-628b48855909");
+		translate.setTranslator(upToDateTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
 	}
@@ -313,7 +315,8 @@ async function queryLibraries(query) {
 	try {
 		let translate = new Zotero.Translate.Search();
 		// Library of Congress ISBN
-		translate.setTranslator("c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9");
+		upToDateTranslator = await Zotero.Translators.updateTranslatorIfNeeded("c070e5a2-4bfd-44bb-9b3c-4be20c50d0d9");
+		translate.setTranslator(upToDateTranslator);
 		translate.setSearch({query});
 		items = await translate.translate({libraryID: false});
 	}
@@ -322,7 +325,8 @@ async function queryLibraries(query) {
 		try {
 			let translate = new Zotero.Translate.Search();
 			// Gemeinsamer Bibliotheksverbund ISBN
-			translate.setTranslator("de0eef58-cb39-4410-ada0-6b39f43383f9");
+			upToDateTranslator = await Zotero.Translators.updateTranslatorIfNeeded("de0eef58-cb39-4410-ada0-6b39f43383f9");
+			translate.setTranslator(upToDateTranslator);
 			translate.setSearch({query});
 			items = await translate.translate({libraryID: false});
 		}

--- a/src/webSession.js
+++ b/src/webSession.js
@@ -237,9 +237,11 @@ WebSession.prototype.translate = async function (translate, translators) {
 	}
 	
 	var translator;
+	var upToDateTranslator;
 	var items;
 	while (translator = translators.shift()) {
-		translate.setTranslator(translator);
+		upToDateTranslator = await Zotero.Translators.updateTranslatorIfNeeded(translator.translatorID);
+		translate.setTranslator(upToDateTranslator);
 		try {
 			items = await translate.translate({
 				libraryID: false


### PR DESCRIPTION
Addresses [Issue # 1](https://github.com/zotero/translation-server/issues/1)
Automatic translator updates for /web requests. The logic is:
1. On load, fetch the metadata. Once it is loaded, check if there are new translators in the metadata that are not present in _cache. Load them up as well if so.
2. Once the request comes in and all relevant translators are fetched, use `updateTranslatorIfNeeded` function to check if their lastUpdated date is before the lastUpdated date in the metadata. If so, load the translator's code from the repo, update the _cache.
3. Returns updated (if applicable) translators to translate the items. 