### PR TITLE
Use PMID endpoint instead of web translator

### DIFF
--- a/src/webSession.js
+++ b/src/webSession.js
@@ -85,6 +85,11 @@ WebSession.prototype.handleURL = async function () {
 			await SearchEndpoint.handleIdentifier(this.ctx, { DOI: doi });
 			return;
 		}
+		let pmid = this.cleanPMIDFromURL(url);
+		if (pmid) {
+			await SearchEndpoint.handleIdentifier(this.ctx, { PMID: pmid });
+			return;
+		}
 	}
 	
 	var responseTypeMap = new Map([
@@ -468,4 +473,13 @@ WebSession.prototype.cleanDOIFromURL = function (url) {
 		doi = doi.replace(/[?&#].*/, '');
 	}
 	return doi || null;
+};
+
+WebSession.prototype.cleanPMIDFromURL = function (url) {
+	let pmid = null;
+	let pmidMatch = decodeURIComponent(url).match(/^https?:\/\/www.ncbi.nlm.nih.gov\/pubmed\/(\d+)\/?/);
+	if (pmidMatch) {
+		pmid = pmidMatch[0];
+	}
+	return pmid;
 };


### PR DESCRIPTION
Use PMID endpoint instead of web translator
for pubmed links as this is the more "polite"
way of accessing PubMed.

Change-Id: Ic3c1a661db65ddc5442f9eaae580275b4fa3499f