### PR TITLE
Handles remote 4xx and 5xx responses and logs them

### DIFF
--- a/src/webSession.js
+++ b/src/webSession.js
@@ -216,6 +216,11 @@ WebSession.prototype.handleURL = async function () {
 			
 			// No more URLs to try
 			if (i == urlsToTry.length - 1) {
+				if (e instanceof Zotero.HTTP.StatusError && e.status >= 400 && e.status < 500) {
+					this.ctx.throw(503, `Remote server could not provide document (${e.status})`);
+				} else if (e instanceof Zotero.HTTP.StatusError && e.status >= 500) {
+					this.ctx.throw(503, `Remote server encountered an error handling our request (${e.status})`);
+				}
 				this.ctx.throw(500, "An error occurred retrieving the document");
 			}
 		}


### PR DESCRIPTION
At present if the remote service returns an error we get an undifferentiated 500 back from translation-server. This means we cannot distinguish between a 403, a 404 or a 500. This change allows us to log what happened.

## Testing
I created a directory called `nginx-force-response` and populated
`conf.d/default.conf` with a file like this (but with more entries):
```
server {
  listen 80;
  server_name localhost;
  location /401 {
    return 401;
  }
  location /501 {
    return 501;
  }
}
```

And then used it like so:
`docker run --rm --name nginx -v $PWD/conf.d:/etc/nginx/conf.d -p 8080:80 nginx`

Finally, I was able to test like this:
```
$ curl -d 'http://127.0.0.1:8080/501' -H "content-type: text/plain" http://localhost:1969/web && echo
Remote server encountered an error handling our request (501)
$ curl -d 'http://127.0.0.1:8080/401' -H "content-type: text/plain" http://localhost:1969/web && echo
Remote server could not provide document (401)
```
