### PR TITLE
Slight improvement to performance regression after JSDOM update that does not actually fix it 

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -40,9 +40,17 @@ global.XPathResult = wgxpath.XPathResultType;
 var { JSDOM } = require('jsdom');
 var serializeNode = require("w3c-xmlserializer");
 
+// Cache shimmed windows to avoid performance issues
+const shimmedWindows = new WeakMap();
+
 let originalWindowProp = Object.getOwnPropertyDescriptor(JSDOM.prototype, 'window');
 Object.defineProperty(JSDOM.prototype, 'window', {
 	get() {
+		// Return cached window if already shimmed
+		if (shimmedWindows.has(this)) {
+			return shimmedWindows.get(this);
+		}
+
 		let win = originalWindowProp.get.call(this);
 
 		// Shimming innerText property for JSDOM attributes, see https://github.com/jsdom/jsdom/issues/1245
@@ -70,6 +78,9 @@ Object.defineProperty(JSDOM.prototype, 'window', {
 			},
 			configurable: true,
 		});
+
+		// Cache the shimmed window for subsequent accesses
+		shimmedWindows.set(this, win);
 		return win;
 	},
 	set(value) {


### PR DESCRIPTION
Commit 4805561c updated the JsDom window getter shim after an update to the jsdom packages in e3b1620a62.

However, the window getter was recreating the shim on every window access which might occur 100s of time per request. In production, CPU usage increased 5x and the service became unstable and crashed constantly.

<img width="540" height="275" alt="Screenshot From 2026-01-13 11-39-29" src="https://github.com/user-attachments/assets/88052a75-e489-474f-987a-4271bebee57a" />
<img width="524" height="391" alt="Screenshot From 2026-01-07 18-22-33" src="https://github.com/user-attachments/assets/30f96553-1216-4826-b2b2-b2f7e21b9620" />

This caches the shimmed properties so they're only defined once per JSDOM instance. Hopefully this fixes the issue!
