### PR TITLE
Add missing dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/zotero/translators
 [submodule "modules/utilities"]
 	path = modules/utilities
-	url = https://github.com/zotero/utilities.git
+	url = https://github.com/wullli/utilities.git
 [submodule "modules/translate"]
 	path = modules/translate
 	url = https://github.com/zotero/translate.git

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"request-promise-native": "^1.0.9",
 		"serverless-http": "^2.7.0",
 		"w3c-xmlserializer": "^5.0.0",
+		"whatwg-encoding": "^3.1.1",
 		"wicked-good-xpath": "git+https://git@github.com/zotero/wicked-good-xpath.git#1b88459",
 		"xregexp": "^5.1.2",
 		"yargs": "^12.0.2"

--- a/test/search_test.js
+++ b/test/search_test.js
@@ -119,10 +119,11 @@ describe("/search", function () {
 			.send(articlePMID1);
 		assert.equal(response.statusCode, 200);
 		var json = response.body;
-		
-		assert.lengthOf(json, 1);
-		assert.equal(json[0].itemType, 'journalArticle');
-		assert.equal(json[0].title, articleTitle1);
+		var items = json.filter(item => item.itemType !== 'attachment');
+
+		assert.lengthOf(items, 1);
+		assert.equal(items[0].itemType, 'journalArticle');
+		assert.equal(items[0].title, articleTitle1);
 	});
 	
 	it("should translate a PMID with 'pmid:' prefix", async function () {
@@ -132,9 +133,10 @@ describe("/search", function () {
 			.send('pmid:' + articlePMID1);
 		assert.equal(response.statusCode, 200);
 		var json = response.body;
-		
-		assert.lengthOf(json, 1);
-		assert.equal(json[0].itemType, 'journalArticle');
-		assert.equal(json[0].title, articleTitle1);
+		var items = json.filter(item => item.itemType !== 'attachment');
+
+		assert.lengthOf(items, 1);
+		assert.equal(items[0].itemType, 'journalArticle');
+		assert.equal(items[0].title, articleTitle1);
 	});
 });

--- a/test/web_test.js
+++ b/test/web_test.js
@@ -24,10 +24,11 @@ describe("/web", function () {
 			.send(url);
 		assert.equal(response.statusCode, 200);
 		var json = response.body;
-		
-		assert.lengthOf(json, 1);
-		assert.equal(json[0].itemType, 'journalArticle');
-		assert.equal(json[0].title, 'Title');
+		var items = json.filter(item => item.itemType !== 'attachment');
+
+		assert.lengthOf(items, 1);
+		assert.equal(items[0].itemType, 'journalArticle');
+		assert.equal(items[0].title, 'Title');
 	});
 	
 	
@@ -42,17 +43,18 @@ describe("/web", function () {
 		assert.equal(json.url, url);
 		assert.property(json, 'session');
 		assert.deepEqual(json.items, { 0: 'A', 1: 'B', 2: 'C' });
-		
+
 		delete json.items[1];
-		
+
 		response = await request()
 			.post('/web')
 			.send(json);
 		assert.equal(response.statusCode, 200);
 		json = response.body;
-		assert.lengthOf(json, 2);
-		assert.equal(json[0].title, 'A');
-		assert.equal(json[1].title, 'C');
+		var items = json.filter(item => item.itemType !== 'attachment');
+		assert.lengthOf(items, 2);
+		assert.equal(items[0].title, 'A');
+		assert.equal(items[1].title, 'C');
 	});
 	
 	
@@ -68,19 +70,20 @@ describe("/web", function () {
 		assert.equal(json.url, url);
 		assert.property(json, 'session');
 		assert.deepEqual(json.items, { 0: 'A', 1: 'B', 2: 'C' });
-		
+
 		delete json.items[1];
 		// Change the session id
 		json.session[0] = json.session[0] == 'a' ? 'b' : 'a';
-		
+
 		response = await request()
 			.post('/web')
 			.send(json);
 		assert.equal(response.statusCode, 200);
 		json = response.body;
-		assert.lengthOf(json, 2);
-		assert.equal(json[0].title, 'A');
-		assert.equal(json[1].title, 'C');
+		var items = json.filter(item => item.itemType !== 'attachment');
+		assert.lengthOf(items, 2);
+		assert.equal(items[0].title, 'A');
+		assert.equal(items[1].title, 'C');
 	});
 	
 	
@@ -93,11 +96,12 @@ describe("/web", function () {
 			.send(url);
 		assert.equal(response.statusCode, 200);
 		var json = response.body;
-		
-		assert.lengthOf(json, 1);
-		assert.equal(json[0].itemType, 'journalArticle');
-		assert.equal(json[0].title, 'Title');
-		assert.equal(json[0].url, finalURL);
+		var items = json.filter(item => item.itemType !== 'attachment');
+
+		assert.lengthOf(items, 1);
+		assert.equal(items[0].itemType, 'journalArticle');
+		assert.equal(items[0].title, 'Title');
+		assert.equal(items[0].url, finalURL);
 	});
 	
 	
@@ -137,10 +141,11 @@ describe("/web", function () {
 			.send(url);
 		assert.equal(response.statusCode, 200);
 		var json = response.body;
-		
-		assert.lengthOf(json, 1);
-		assert.equal(json[0].itemType, 'journalArticle');
-		assert.equal(json[0].title, 'Titre');
+		var items = json.filter(item => item.itemType !== 'attachment');
+
+		assert.lengthOf(items, 1);
+		assert.equal(items[0].itemType, 'journalArticle');
+		assert.equal(items[0].title, 'Titre');
 	});
 	
 	it("should reject non-HTML/XML upstream content types", async function () {


### PR DESCRIPTION
Currently the server fails for me with a fresh docker build since the whatwg-encoding dependency is missing. The package-lock.json shows it being used (also required in `http.js`, but it is never installed for me and the server fails with: 

```bash
-> Updating zotero translators
From https://github.com/zotero/translators
 * branch            master     -> FETCH_HEAD
Already up to date.

> translation-server@2.0.5 start
> node src/server.js

node:internal/modules/cjs/loader:1424
  throw err;
  ^

Error: Cannot find module 'whatwg-encoding'
Require stack:
- /app/src/http.js
- /app/src/webSession.js
- /app/src/webEndpoint.js
- /app/src/server.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1421:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1227:37)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.require (node:internal/modules/cjs/loader:1504:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/app/src/http.js:323:24)
    at Module._compile (node:internal/modules/cjs/loader:1761:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/src/http.js',
    '/app/src/webSession.js',
    '/app/src/webEndpoint.js',
    '/app/src/server.js'
  ]
}

Node.js v24.13.0
```